### PR TITLE
always convert trusted proxies to string

### DIFF
--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -41,7 +41,7 @@ module Sentry
     end
 
     def configure_trusted_proxies
-      Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies)
+      Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies).map(&:to_s)
     end
 
     def extend_active_job


### PR DESCRIPTION
fix https://github.com/getsentry/sentry-ruby/issues/1274

## Description

`IPAddr.new` only accept the address as a string but not as an `IPAddr` as suggested in the [Rails documentation](https://api.rubyonrails.org/classes/ActionDispatch/RemoteIp.html).
